### PR TITLE
Symbolically evaluate BR for branch tables

### DIFF
--- a/src/analyse/CallGraph.ml
+++ b/src/analyse/CallGraph.ml
@@ -155,7 +155,8 @@ let pp_call_graph test (instructions, index_of_address, _address_of_index, _indi
     match todo with
     | [] -> (acc_reachable, acc_bl_targets)
     | k :: todo' ->
-        if List.mem k acc_reachable then stupid_reachability acc_reachable acc_bl_targets todo'
+        if List.mem Int.equal k acc_reachable then
+          stupid_reachability acc_reachable acc_bl_targets todo'
         else if not (k < Array.length instructions) then
           stupid_reachability acc_reachable acc_bl_targets todo'
         else

--- a/src/analyse/ControlFlow.ml
+++ b/src/analyse/ControlFlow.ml
@@ -306,13 +306,13 @@ let parse_drop_one s =
 let parse_control_flow_instruction s mnemonic s' : control_flow_insn =
   (*   Printf.printf "s=\"%s\" mnemonic=\"%s\"  mnemonic chars=\"%s\" s'=\"%s\"   "s mnemonic (String.concat "," (List.map (function c -> string_of_int (Char.code c)) (char_list_of_string mnemonic))) s';flush stdout;*)
   let c =
-    if List.mem mnemonic [".word"] then C_no_instruction
-    else if List.mem mnemonic ["ret"] then C_ret
-    else if List.mem mnemonic ["eret"] then C_eret
-    else if List.mem mnemonic ["br"] then C_branch_register mnemonic
+    if List.mem String.equal mnemonic [".word"] then C_no_instruction
+    else if List.mem String.equal mnemonic ["ret"] then C_ret
+    else if List.mem String.equal mnemonic ["eret"] then C_eret
+    else if List.mem String.equal mnemonic ["br"] then C_branch_register mnemonic
     else if
       (String.length mnemonic >= 2 && String.sub mnemonic 0 2 = "b.")
-      || List.mem mnemonic ["b"; "bl"]
+      || List.mem String.equal mnemonic ["b"; "bl"]
     then
       match parse_target s' with
       | None -> raise (Failure ("b./b/bl parse error for: \"" ^ s ^ "\"\n"))
@@ -320,7 +320,7 @@ let parse_control_flow_instruction s mnemonic s' : control_flow_insn =
           if mnemonic = "b" then C_branch (a, s)
           else if mnemonic = "bl" then C_branch_and_link (a, s)
           else C_branch_cond (mnemonic, a, s)
-    else if List.mem mnemonic ["cbz"; "cbnz"] then
+    else if List.mem String.equal mnemonic ["cbz"; "cbnz"] then
       match parse_drop_one s' with
       | None -> raise (Failure ("cbz/cbnz 1 parse error for: " ^ s ^ "\n"))
       | Some s' -> (
@@ -328,7 +328,7 @@ let parse_control_flow_instruction s mnemonic s' : control_flow_insn =
           | None -> raise (Failure ("cbz/cbnz 2 parse error for: " ^ s ^ "\n"))
           | Some (a, s) -> C_branch_cond (mnemonic, a, s)
         )
-    else if List.mem mnemonic ["tbz"; "tbnz"] then
+    else if List.mem String.equal mnemonic ["tbz"; "tbnz"] then
       match parse_drop_one s' with
       | None -> raise (Failure ("tbz/tbnz 1 parse error for: " ^ s ^ "\n"))
       | Some s'' -> (
@@ -342,7 +342,7 @@ let parse_control_flow_instruction s mnemonic s' : control_flow_insn =
                   C_branch_cond (mnemonic, a, s'''')
             )
         )
-    else if List.mem mnemonic ["smc"; "hvc"] then C_smc_hvc s'
+    else if List.mem String.equal mnemonic ["smc"; "hvc"] then C_smc_hvc s'
     else C_plain
   in
   (*Printf.printf "%s\n" (pp_control_flow_instruction c);*)
@@ -366,7 +366,7 @@ let targets_of_control_flow_insn_without_index branch_table_targets (addr : natu
     | C_branch_and_link (a, s) ->
         (* special-case non-return functions to have no successor target of calls *)
         (* TODO: pull this from the DWARF attributes *)
-        if List.mem s ["<abort>"; "<panic>"; "<__stack_chk_fail>"] then
+        if List.mem String.equal s ["<abort>"; "<panic>"; "<__stack_chk_fail>"] then
           [(T_branch_and_link_call_noreturn, a, s)]
         else
           [(T_branch_and_link_call, a, s); (T_branch_and_link_successor, succ_addr, "<return>")]

--- a/src/analyse/ControlFlowPpText.ml
+++ b/src/analyse/ControlFlowPpText.ml
@@ -138,7 +138,7 @@ let render_ascii_control_flow max_branch_distance max_width instructions :
 
     let try_at_column dry_run c =
       let try_for_row k =
-        let is_target = List.mem k a.targets in
+        let is_target = List.mem Int.equal k a.targets in
         let is_source = k = a.source in
         let is_self_target = is_target && is_source in
 
@@ -248,12 +248,12 @@ let render_ascii_control_flow max_branch_distance max_width instructions :
           Array.map2
             (fun g1 g2 ->
               if
-                List.mem g1 [Gud L; Grd L; Grud L; Glrud (L, L); Glrud (B, L)]
-                && List.mem g2 [Gud L; Gru L; Grud L; Glrud (L, L); Glrud (B, L)]
+                List.mem Stdlib.( = ) g1 [Gud L; Grd L; Grud L; Glrud (L, L); Glrud (B, L)]
+                && List.mem Stdlib.( = ) g2 [Gud L; Gru L; Grud L; Glrud (L, L); Glrud (B, L)]
               then Gud L
               else if
-                List.mem g1 [Gud B; Grd B; Grud B; Glrud (L, B); Glrud (B, B)]
-                && List.mem g2 [Gud B; Gru B; Grud B; Glrud (L, B); Glrud (B, B)]
+                List.mem Stdlib.( = ) g1 [Gud B; Grd B; Grud B; Glrud (L, B); Glrud (B, B)]
+                && List.mem Stdlib.( = ) g2 [Gud B; Gru B; Grud B; Glrud (L, B); Glrud (B, B)]
               then Gud B
               else Gnone)
             (Array.sub buf.(k - 1) !leftmost_column_used width)

--- a/src/analyse/DwarfInliningInfo.ml
+++ b/src/analyse/DwarfInliningInfo.ml
@@ -95,7 +95,7 @@ let mk_inlining test sdt instructions =
             if List.length labels_in_use >= 26 then fatal "%s" "inlining depth > 26";
             let rec fresh_label l =
               let l = (l + 1) mod 26 in
-              if not (List.mem l labels_in_use) then l else fresh_label l
+              if not (List.mem Int.equal l labels_in_use) then l else fresh_label l
             in
             let l = fresh_label label_last in
             enlabel (l :: labels_in_use) l ((l, issr) :: acc) issr_new'

--- a/src/arch/aarch64/dune
+++ b/src/arch/aarch64/dune
@@ -4,4 +4,16 @@
  (flags
   (:standard -open Utils))
  (implements sig)
+ (inline_tests
+  (backend read-dwarf.qtest.sig.aarch64))
  (libraries utils config state))
+
+(library
+ (name qtest_sig_aarch64)
+ (public_name read-dwarf.qtest.sig.aarch64)
+ (modules)
+ (inline_tests.backend
+  (generate_runner
+   (run qtest extract --preamble "open Utils;;" --quiet %{impl-files}
+     %{intf-files}))
+  (runner_libraries qcheck ounit2 bytes)))

--- a/src/arch/aarch64/sig.ml
+++ b/src/arch/aarch64/sig.ml
@@ -362,8 +362,7 @@ let assemble_to_elf instr =
 
 let split_into_instrs = BytesSeq.to_listbs ~len:4
 
-(** https://developer.arm.com/docs/ddi0596/h/base-instructions-alphabetic-order/ret-return-from-subroutine
-    TODO Add tests *)
+(** https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/RET--Return-from-subroutine- *)
 let is_ret code =
   assert (BytesSeq.length code = 4);
   let (( = ), ( land )) = Int32.(( = ), logand) in
@@ -373,13 +372,33 @@ let is_ret code =
   let ret_with_reg_zero = 0x00005fd6l in
   zero_out_reg_operand_mask land code = ret_with_reg_zero
 
-(** https://developer.arm.com/docs/ddi0596/h/base-instructions-alphabetic-order/cmp-immediate-compare-immediate-an-alias-of-subs-immediate
-    TODO Add tests *)
-let is_cmp code_bs =
+(*$inject
+let to_be_bytes_seq int32 =
+  let result = Bytes.create 4 in
+  Bytes.set_int32_le result 0 int32;
+  BytesSeq.of_bytes result
+*)
+
+(*$T is_ret
+     (0xd65f0000l |> to_be_bytes_seq |> is_ret)
+     (0xd65f01e0l |> to_be_bytes_seq |> is_ret)
+     (0xd65f02c0l |> to_be_bytes_seq |> is_ret)
+     (0xd65f03a0l |> to_be_bytes_seq |> is_ret)
+     (0xd65f0490l |> to_be_bytes_seq |> is_ret |> not)
+     (0xd65f0770l |> to_be_bytes_seq |> is_ret |> not)
+     (0xd65f0b50l |> to_be_bytes_seq |> is_ret |> not)
+     (0xd65f0f30l |> to_be_bytes_seq |> is_ret |> not)
+     (0x9100001fl |> to_be_bytes_seq |> is_ret |> not)
+*)
+
+(*${*)
+
+(** https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/CMP--immediate---Compare--immediate---an-alias-of-SUBS--immediate-- *)
+let is_cmp' code_bs =
   assert (BytesSeq.length code_bs = 4);
   let (( = ), ( land )) = Int32.(( = ), logand) in
   let code = BytesSeq.get32be code_bs 0 in
-  let zero_out_operands_mask = 0x1f00087fl in
+  let zero_out_operands_mask = 0x1f00807fl in
   let cmp_with_zero_operands = 0x1f000071l in
   if zero_out_operands_mask land code = cmp_with_zero_operands then
     let open BitVec in
@@ -394,12 +413,38 @@ let is_cmp code_bs =
     let bottom12 = of_int ~size 0x00000fff in
     (* values are 64 bits, spec says imm12 is unsigned *)
     let value = BitVec.zero_extend size @@ (code_bv land bottom12) in
-    (* fixup types *)
-    match Reg.of_int reg with Some reg -> Some (reg, value) | None -> Raise.unreachable ()
+    Some (reg, value)
   else None
 
-(** https://developer.arm.com/docs/ddi0596/h/base-instructions-alphabetic-order/bl-branch-with-link
-    TODO Add tests *)
+(*$}*)
+
+(*$inject
+let check_cmp (reg, value) = function
+  | Some (reg', value') -> reg = reg' && value = BitVec.to_int value'
+  | None -> false
+*)
+
+(*$T is_cmp'
+     (0x7100001fl |> to_be_bytes_seq |> is_cmp' |> check_cmp (0, 0))
+     (0xf100009fl |> to_be_bytes_seq |> is_cmp' |> check_cmp (4, 0))
+     (0x7100745fl |> to_be_bytes_seq |> is_cmp' |> check_cmp (2, 0x1d))
+     (0x7172695fl |> to_be_bytes_seq |> is_cmp' |> check_cmp (10, 0xc9a))
+     (0xf118171fl |> to_be_bytes_seq |> is_cmp' |> check_cmp (24, 0x605))
+     (0xf100313fl |> to_be_bytes_seq |> is_cmp'	|> check_cmp (9, 0xc))
+     (0x6100313fl |> to_be_bytes_seq |> is_cmp'	|> Option.is_none)
+     (0xf600313fl |> to_be_bytes_seq |> is_cmp'	|> Option.is_none)
+     (0xf1a0313fl |> to_be_bytes_seq |> is_cmp'	|> Option.is_none)
+     (0xf10031cfl |> to_be_bytes_seq |> is_cmp'	|> Option.is_none)
+     (0xf100313el |> to_be_bytes_seq |> is_cmp'	|> Option.is_none)
+*)
+
+let is_cmp code_bs =
+  Option.(
+    let* (reg, value) = is_cmp' code_bs in
+    (* fixup types *)
+    match Reg.of_int reg with Some reg -> Some (reg, value) | None -> Raise.unreachable ())
+
+(** https://developer.arm.com/documentation/ddi0596/2020-12/Base-Instructions/BL--Branch-with-Link- *)
 let is_bl code_bs =
   assert (BytesSeq.length code_bs = 4);
   let (( = ), ( land )) = Int32.(( = ), logand) in
@@ -415,5 +460,17 @@ let is_bl code_bs =
     let two = of_int ~size 2 in
     (* values are 64 bits, spec says imm26 is multiplied by 4
        (shifted left by 2) and sign extended *)
-    Some (BitVec.sign_extend size @@ ((code_bv land bottom26) lsl two))
+    Some (BitVec.sign_extend 64 @@ BitVec.extract 0 27 ((code_bv land bottom26) lsl two))
   else None
+
+(*$inject
+let check_bl y = function None -> false | Some x -> x |> BitVec.to_z |> Z.equal (Z.of_int64 y)
+*)
+
+(*$T is_bl
+     (0x96030000l |> to_be_bytes_seq |> is_bl |> check_bl 0xfffffffff80c0000L)
+     (0x95000009l |> to_be_bytes_seq |> is_bl |> check_bl 0x4000024L)
+     (0x35000009l |> to_be_bytes_seq |> is_bl |> Option.is_none)
+     (0x93000009l |> to_be_bytes_seq |> is_bl |> Option.is_none)
+     (0x9b000009l |> to_be_bytes_seq |> is_bl |> Option.is_none)
+*)

--- a/src/arch/sig.mli
+++ b/src/arch/sig.mli
@@ -110,3 +110,17 @@ val assemble_to_elf : string -> string
 
 (**  Split a byte-sequence into a list of instructions. *)
 val split_into_instrs : BytesSeq.t -> BytesSeq.t list
+
+(** Tell if an instruction is a return instruction. *)
+val is_ret : BytesSeq.t -> bool
+
+(** Tell if an instruction is a compare instruction.
+    Returns [Some (reg,bv)] where the contents of [reg] are compared against the
+    value [bv] if it is and [None] if not. *)
+val is_cmp : BytesSeq.t -> (State.Reg.t * BitVec.t) option
+
+(** Tell if an instruction is an (unconditional) branch on immediate with
+    link instructions.  Returns [Some bv] where [bv] is the offset (from the
+    address of this instruction, in the range +/-128MB) that is branched to
+    if it is and [None] if not. *)
+val is_bl : BytesSeq.t -> BitVec.t option

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -4,7 +4,7 @@
  (modules main)
  (flags
   (:standard -open Utils))
- (libraries config run utils sig_aarch64 other_cmds))
+ (libraries config run utils sig_aarch64 other_cmds branchTable))
 
 (library
  (name other_cmds)

--- a/src/branchTable/branchTable.ml
+++ b/src/branchTable/branchTable.ml
@@ -1,0 +1,501 @@
+(*==================================================================================*)
+(*  BSD 2-Clause License                                                            *)
+(*                                                                                  *)
+(*  Copyright (c) 2020-2021 Thibaut Pérami                                          *)
+(*  Copyright (c) 2020-2021 Dhruv Makwana                                           *)
+(*  Copyright (c) 2019-2021 Peter Sewell                                            *)
+(*  All rights reserved.                                                            *)
+(*                                                                                  *)
+(*  This software was developed by the University of Cambridge Computer             *)
+(*  Laboratory as part of the Rigorous Engineering of Mainstream Systems            *)
+(*  (REMS) project.                                                                 *)
+(*                                                                                  *)
+(*  This project has been partly funded by EPSRC grant EP/K008528/1.                *)
+(*  This project has received funding from the European Research Council            *)
+(*  (ERC) under the European Union's Horizon 2020 research and innovation           *)
+(*  programme (grant agreement No 789108, ERC Advanced Grant ELVER).                *)
+(*  This project has been partly funded by an EPSRC Doctoral Training studentship.  *)
+(*  This project has been partly funded by Google.                                  *)
+(*                                                                                  *)
+(*  Redistribution and use in source and binary forms, with or without              *)
+(*  modification, are permitted provided that the following conditions              *)
+(*  are met:                                                                        *)
+(*  1. Redistributions of source code must retain the above copyright               *)
+(*     notice, this list of conditions and the following disclaimer.                *)
+(*  2. Redistributions in binary form must reproduce the above copyright            *)
+(*     notice, this list of conditions and the following disclaimer in              *)
+(*     the documentation and/or other materials provided with the                   *)
+(*     distribution.                                                                *)
+(*                                                                                  *)
+(*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''              *)
+(*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED               *)
+(*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                 *)
+(*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR             *)
+(*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                    *)
+(*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                *)
+(*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                *)
+(*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND             *)
+(*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,              *)
+(*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT              *)
+(*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF              *)
+(*  SUCH DAMAGE.                                                                    *)
+(*                                                                                  *)
+(*==================================================================================*)
+
+(** This module is designed to symbolically evaluate all the branch tables in an ELF file. 
+    Known bugs:
+    - How to handle the following for live = [x9] ?
+      40812c:       2a0803e9        mov     w9, w8
+      408130:       2a0903e8        mov     w8, w9
+      408134:       71000d08        subs    w8, w8, #0x3
+    - Multiple starts *)
+
+open Cmdliner
+open Config.CommonOpt
+
+open Logs.Logger (struct
+  let str = __MODULE__
+end)
+
+module Analyses = InstrsAnalyses
+module Reg = State.Reg
+module Instr = Trace.Instr
+module Runner = Run.Runner
+module Block = Run.Block_lib
+module ConcreteEval = Exp.ConcreteEval
+module Value = Exp.Value
+
+let pp_regs regs = Pp.(top (list Reg.pp) regs)
+
+let pp_ptrs ptrs = Pp.(top (list ptr) ptrs)
+
+type and_t = AndS of Reg.t * BitVec.t | Mask of Reg.t * Reg.t * BitVec.t
+
+let looks_like_ands (trace0 : Instr.trace_meta) (trace1 : Instr.trace_meta) =
+  (* Trace 1: [ Assert !(reg:R20[0:0] = 0:1), ... ] *)
+  let assert_not_low_bit = function
+    | Trace.Assert
+        (Unop
+          (Not, Binop (Eq, Unop (Extract (0, 0), Var (Register rn, _), _), Bits (bits, _), _), _))
+      when BitVec.size bits = 1 ->
+        Some (rn, bits)
+    | _ -> None
+  in
+  (* Trace 0: [ Assert reg:R20[0:0] = 0:1, ... ] *)
+  let assert_low_bit = function
+    | Trace.Assert (Binop (Eq, Unop (Extract (0, 0), Var (Register rn, _), _), Bits (bits, _), _))
+      when BitVec.size bits = 1 ->
+        Some (rn, bits)
+    | _ -> None
+  in
+  Option.(
+    let* event0 = List.nth_opt trace0.trace 0 and* event1 = List.nth_opt trace1.trace 0 in
+    let* (reg0, bit0) = assert_low_bit event0 and* (reg1, bit1) = assert_not_low_bit event1 in
+    assert (Reg.(reg0 = reg1) && BitVec.(size bit0 = size bit1 && to_z bit0 = to_z bit1));
+    Some (AndS (reg0, BitVec.zero_extend 31 bit0)))
+
+let looks_like_and_low_mask rd value =
+  match value with
+  (* Beware of following, hence [hi < 31]
+       Write |reg:R8| with 0x0:60@reg:R1[0:3]    -- "and w8, w1, #0xf"
+       Write |reg:R2| with 0x0:32@reg:R19[0:31]  -- "mov w2, w19" *)
+  | Ast.Manyop
+      ( Concat,
+        [Bits (maybeZeros, _); Unop (Extract (hi, 0), Var (Trace.Var.Register rn, _), _)],
+        _ )
+    when BitVec.to_z maybeZeros = Z.zero && hi < 31 ->
+      Some (Mask (rd, rn, BitVec.of_int ~size:32 ((1 lsl (hi + 1)) - 1)))
+  | _ -> None
+
+let looks_like_and = function
+  | [] | _ :: _ :: _ :: _ -> None
+  | [trace0; trace1] -> looks_like_ands trace0 trace1
+  | [{ Instr.trace; jump_target = _; read = _; written = _ }] -> (
+      match trace with
+      | [] | [(Trace.Assert _ | ReadMem _ | WriteMem _)] | _ :: _ :: _ -> None
+      | [WriteReg { reg = rd; value }] -> looks_like_and_low_mask rd value
+    )
+
+let looks_like_csel = function
+  | [] | _ :: _ :: _ -> false
+  | [{ Instr.trace; jump_target = _; read = _; written = _ }] -> (
+      match trace with
+      | [] | [(Trace.Assert _ | ReadMem _ | WriteMem _)] | _ :: _ :: _ -> false
+      | [WriteReg { reg = _; value }] -> (
+          let is_reg = function Ast.Var (Trace.Var.Register _, _) -> true | _ -> false in
+          let is_bool = function Ast.Bits (bits, _) -> BitVec.size bits = 1 | _ -> false in
+          match value with
+          (* Write |reg:R3| with if reg:PSTATE.Z = 1:1 then reg:R3 else reg:R0 *)
+          | Ite (Binop (Eq, e1, bits, _), e2, e3, _)
+            when is_reg e1 && is_bool bits && is_reg e2 && is_reg e3 ->
+              true
+          | _ -> false
+        )
+    )
+
+type cmp_case = RangeFrom0 | Eq_Neq
+
+(** Two things are 'fixed' for the reads and writes:
+    - Reads of the PC and SP are removed since they are always live
+    - Comparisons of a register with a constant are considered a write, because
+      we set the value of the register with a range of constants before simulating. *)
+let fixup_written_read instr_at addr { Instr.read; written; opcode; traces; length } =
+  let always_live =
+    let pc = Arch.pc () and sp = Arch.sp () in
+    fun x -> x = pc || x = sp
+  in
+  let is_cmp_we_care_about =
+    (* NOTE This is definitely wrong, but not worthwhile to do accurately.
+       Specifically, the code assumes that
+       - a conditional branch instruction is checking (the NZCV flags) to see
+         if the register was was less than a bound
+       - anything else checks merely for equality. *)
+    Option.(
+      let* res = Arch.is_cmp opcode in
+      let rec loop limit addr length =
+        if limit = 0 then (
+          debug "No csel/b._ found after cmp";
+          None
+        )
+        else
+          (* Sadly, the branch/conditional instruction may not follow the cmp immediately *)
+          let loop = loop (limit - 1) in
+          let next_addr = addr + length in
+          let* next = instr_at next_addr in
+          match next with
+          | Runner.Nocode -> None
+          | Special next_len | IslaFail next_len -> loop next_addr next_len
+          | Normal ({ length = next_len; traces; _ } as next) -> (
+              match Analyses.looks_like_a_branch next next_addr with
+              (* If a compare is followed by a conditional branch,
+                 assume it needs a range of values. *)
+              | Some (Analyses.Simple (_, falls_thru)) ->
+                  if falls_thru then Some (RangeFrom0, res) else loop next_addr next_len
+              | None ->
+                  if looks_like_csel traces then Some (Eq_Neq, res) else loop next_addr next_len
+              | Some (Reg _) -> None
+            )
+      in
+      loop 5 addr length)
+  in
+  match is_cmp_we_care_about with
+  | None -> (
+      match looks_like_and traces with
+      | None -> (is_cmp_we_care_about, written, List.filter Fun.(negate always_live) read)
+      | Some (AndS (reg, imm)) ->
+          ( Some (Eq_Neq, (reg, imm)),
+            reg :: written,
+            List.filter (fun x -> x <> reg && not (always_live x)) read )
+      | Some (Mask (_rd, rn, imm)) ->
+          ( Some (RangeFrom0, (rn, imm)),
+            (* _rd is already here *) written,
+            List.filter (fun x -> x <> rn && not (always_live x)) read )
+    )
+  | Some (_, (reg, _)) ->
+      ( is_cmp_we_care_about,
+        reg :: written,
+        List.filter (fun x -> x <> reg && not (always_live x)) read )
+
+type dataflow_context = {
+  instr_at : int -> Runner.slot option;
+  comes_before : int -> (int * int list) option;
+  spills_for : int -> int list;
+  depth_limit : int;
+  relevant_instrs : (int, unit) Hashtbl.t;
+  relevant_spills : (int, bool) Hashtbl.t;
+  live : Reg.t list;
+  cmp_operands : (cmp_case * (Reg.t * BitVec.t)) option;
+}
+
+exception DeadEnd
+
+exception MultipleStarts
+
+(** A standard backwards-dataflow analysis with following modifications:
+    - comparisons with constants are treated as writes
+    - irrelevant instructions (those which do not write to any live registers) are ignored
+    - relevant instructions are tracked and returned
+    - the operands of the first relevant comparison with a constant (which is followed by
+      a conditional branch) are also returned, if it exists *)
+let rec update_live ctxt addr =
+  debug "  visiting %#x" addr;
+  if ctxt.depth_limit = 0 then fail "Hit branch table calculation depth limit"
+  else
+    let (is_cmp_we_care_about, written, read) =
+      match ctxt.instr_at addr with
+      | None | Some Runner.Nocode -> Raise.unreachable ()
+      | Some (Special _ | IslaFail _) -> (None, [], [])
+      | Some (Normal instr) -> fixup_written_read ctxt.instr_at addr instr
+    in
+    let (cmp_operands, live) =
+      let (relevant_regs, rest) =
+        List.partition (fun x -> List.mem Reg.( = ) x written) ctxt.live
+      in
+      let relevant_spill = Hashtbl.mem ctxt.relevant_spills addr in
+      if relevant_spill then Hashtbl.replace ctxt.relevant_spills addr true;
+      if not (relevant_regs <> [] || relevant_spill) then (
+        ( match is_cmp_we_care_about with
+        | Some (RangeFrom0, _) ->
+            if ctxt.cmp_operands = None then fail "IRRELEVANT EARLY RANGE %#x" addr
+        | Some (Eq_Neq, _) ->
+            if ctxt.cmp_operands = None then fail "IRRELEVANT EARLY EQ_NEQ %#x" addr
+        | None -> ()
+        );
+        (ctxt.cmp_operands, ctxt.live)
+      )
+      else (
+        Hashtbl.add ctxt.relevant_instrs addr ();
+        List.iter (Fun.flip (Hashtbl.add ctxt.relevant_spills) false) @@ ctxt.spills_for addr;
+        let live = List.sort_uniq Reg.compare @@ read @ rest in
+        debug "  instr at %#x writes %t, live %t" addr (pp_regs written) (pp_regs live);
+        (* Save the operands of the first relevant compare. This is used later, for
+           setting the value of the compared register with a range of values before
+           simulating the branch-register calculation. *)
+        (Option.fold ~none:is_cmp_we_care_about ~some:Option.some ctxt.cmp_operands, live)
+      )
+    in
+    match live with
+    | [] -> (
+        let not_seen_spills =
+          Hashtbl.fold
+            (fun key seen acc -> if seen then acc else key :: acc)
+            ctxt.relevant_spills []
+        in
+        match not_seen_spills with
+        | [] -> (addr, ctxt.relevant_instrs, cmp_operands)
+        | [addr] -> update_live { ctxt with live; cmp_operands } addr
+        | _ :: _ -> fail "No idea how to implement this"
+      )
+    | _ :: _ -> step_backwards { ctxt with live; cmp_operands } addr
+
+(* A standard backwards traversal with cycle-prevention and backtracking.
+   If more than one answer, it fails - the simluation relies on straight-line execution. *)
+and step_backwards ctxt addr =
+  match ctxt.comes_before addr with
+  | None -> raise DeadEnd
+  | Some (next, nexts) -> (
+      (* We use addresses to break cycles in the comes-before graph *)
+      let filtered = List.filter (fun nxt -> nxt < addr) (next :: nexts) in
+      match filtered with
+      | [] ->
+          info "  DeadEnd %t come before %#x" (pp_ptrs @@ (next :: nexts)) addr;
+          raise DeadEnd
+      | [addr] -> update_live { ctxt with depth_limit = ctxt.depth_limit - 1 } addr
+      | _ :: _ :: _ -> (
+          let ans = ref [] in
+          debug "  Trying multiple paths %t" (pp_ptrs filtered);
+          List.iter
+            (fun addr ->
+              try
+                let ctxt =
+                  {
+                    ctxt with
+                    depth_limit = ctxt.depth_limit - 1;
+                    relevant_instrs = Hashtbl.copy ctxt.relevant_instrs;
+                    relevant_spills = Hashtbl.copy ctxt.relevant_spills;
+                  }
+                in
+                ans := update_live ctxt addr :: !ans
+              with DeadEnd -> ())
+            filtered;
+          match !ans with
+          | [ans] -> ans
+          | [] -> raise DeadEnd
+          | _ :: _ :: _ ->
+              info "  More than one start found: %t"
+                (pp_ptrs @@ List.map (fun (x, _, _) -> x) !ans);
+              raise MultipleStarts
+        )
+    )
+
+(** Work backwards through the dataflow of the registers to find the earliest
+    instruction from which point to run a straight-line simluation.
+
+    This function returns a tuple containing:
+    - the address of the start of the branch-register target computation
+    - the set of instruction addresses which are relevant between the start
+      (inclusive) and the branch-register instruction (exclusive)
+    - the register that must be set with a value before simulating the
+      relevant instructions
+    - the inclusive maximum value which that register should be set to *)
+let reverse_dataflow instructions comes_before spills (reg_branches : Analyses.reg_branches) =
+  let process (br, regs) =
+    debug "Computing dataflow for branch at %#x with initial live registers %t" br (pp_regs regs);
+    let ctxt =
+      {
+        instr_at = Hashtbl.find_opt instructions;
+        comes_before = Hashtbl.find_opt comes_before;
+        spills_for = Hashtbl.find_all (Lazy.force spills);
+        depth_limit = 1000;
+        relevant_instrs = Hashtbl.create 10;
+        relevant_spills = Hashtbl.create 10;
+        live = regs;
+        cmp_operands = None;
+      }
+    in
+    let (start, relevant_instrs, cmp_reg_bits_opt) = step_backwards ctxt br in
+    (br, (start, relevant_instrs, cmp_reg_bits_opt))
+  in
+  List.map process (reg_branches :> (int * Reg.t list) list)
+
+let make_block runner (br, (start, relevant, cmp_reg_bits_opt)) =
+  (* Add the br instruction itself: this means the target is always in the PC *)
+  Hashtbl.add relevant br ();
+  ( br,
+    ( (* The result of Block.gen_endpred keeps track of PCs that have been seen before,
+         so you can't reuse it for multiple executions of the same sequence of instructions. *)
+      (fun () ->
+        (* Argument [~max] is treated as exclusive, so [~max:(br + 1)] to get
+           the final target in the PC itself *)
+        let endpred = Block.gen_endpred ~min:start ~max:(br + 1) ~loop:1 ~brks:[] () in
+        Block.make ~runner ~start ~endpred),
+      relevant,
+      cmp_reg_bits_opt ) )
+
+type pc_exp_guess = Sym of Block.label State.Tree.t | Ints of Block.label State.Tree.t array
+
+let symeval_range_for_trees elf start (block, relevant, cmp_reg_bits_opt) =
+  let start_with reg bits =
+    let st = State.copy ~elf start in
+    State.set_reg st reg { ctyp = None; exp = Exp.Typed.bits bits };
+    State.lock st;
+    st
+  in
+  match cmp_reg_bits_opt with
+  | None -> Sym (Block.run ~relevant (block ()) start)
+  | Some (Eq_Neq, (cmp_reg, cmp_bits)) ->
+      let start_eq = start_with cmp_reg cmp_bits in
+      let start_neq = start_with cmp_reg BitVec.(add (of_int ~size:64 1) cmp_bits) in
+      Ints [|Block.run ~relevant (block ()) start_eq; Block.run ~relevant (block ()) start_neq|]
+  | Some (RangeFrom0, (cmp_reg, cmp_bits)) ->
+      let incl_max = BitVec.to_int cmp_bits in
+      debug "Setting reg %t with values 0x0 - %#x" (Pp.top Reg.pp cmp_reg) incl_max;
+      Ints
+        (Array.init (incl_max + 1) (fun i ->
+             Block.run ~every_instruction:true ~relevant (block ())
+               (start_with cmp_reg (BitVec.of_int ~size:64 i))))
+
+type 'a target = Sym of State.exp * (State.var * State.exp) list | Conc of 'a list
+
+let map_target f = function Sym _ as x -> x | Conc xs -> Conc (List.map f xs)
+
+let exp_to_int ?ctxt exp = exp |> ConcreteEval.eval ?ctxt |> Value.expect_bv |> BitVec.to_int
+
+let target_to_ints =
+  let zero = Value.Bv (BitVec.of_int ~size:64 0) in
+  function Conc x -> x | Sym (x, _) -> [exp_to_int ~ctxt:(Fun.const zero) x]
+
+let int_or_sym (st, exp) =
+  try Conc [exp_to_int exp]
+  with ConcreteEval.Symbolic ->
+    debug "symbolic pc: %t" (Pp.top State.pp st);
+    let to_addr_exp (block : State.Mem.Fragment.Block.t) =
+      let open Exp.Typed in
+      let offset = bits_int ~size:64 block.offset in
+      Option.fold ~none:offset ~some:(Fun.flip ( + ) offset) block.base
+    in
+    let get_read : State.Mem.Fragment.Event.t -> _ option = function
+      | Read (block, addr) -> Some (addr, to_addr_exp block)
+      | Write _ -> None
+    in
+    Sym (exp, List.filter_map get_read @@ State.Mem.(Fragment.get_trace @@ get_main st.mem))
+
+let pp_target =
+  let open Pp in
+  function
+  | Conc x -> concat @@ List.map (fun x -> string ", " ^^ ptr x) x
+  | Sym (x, reads) ->
+      let open State in
+      let pp_read (var, exp) = concat [bar; Var.pp var; bar; string " from "; Exp.pp exp] in
+      concat [Exp.pp x; string " where "; list pp_read reads]
+
+let extract_branch_targets pc : pc_exp_guess -> int target =
+  let rec linear (x : _ State.Tree.t) = List.length x.rest <= 1 && List.for_all linear x.rest in
+  let last_state tree =
+    assert (linear tree);
+    tree |> State.Tree.map_to_list (fun _ state -> state) |> List.last
+  in
+  let pc_exp state = State.(Tval.exp @@ get_reg state pc) in
+  function
+  | Sym tree -> last_state tree |> Pair.split |> Pair.map Fun.id pc_exp |> int_or_sym
+  | Ints tree_array ->
+      assert (Array.for_all linear tree_array);
+      Conc
+        (tree_array
+        |> Array.map (fun tree -> last_state tree |> pc_exp |> exp_to_int)
+        |> Array.to_list |> List.sort_uniq Int.compare
+        )
+
+let process_sym names (dwarf : Dw.t) start =
+  let elf = dwarf.elf in
+  Elf.SymTable.fold elf.symbols [] (fun sym acc ->
+      if not (sym.typ = FUNC && (names = [] || List.mem String.equal sym.name names)) then acc
+      else (
+        info "Starting %s" sym.name;
+        (* New runner each time to not accumulate instructions *)
+        let runner = Runner.of_dwarf dwarf in
+        let runner = { runner with dwarf = None } in
+        Runner.load_sym runner sym;
+        let (simp, reg) = Analyses.find_branches runner.instrs in
+        try
+          (simp, reg) |> Pair.map Pair.split Fun.id
+          |> Pair.map
+               Analyses.(
+                 Pair.map (compute_comes_before runner.instrs) (fun x ->
+                     lazy (track_spills runner.instrs x)))
+               Fun.id
+          |> Fun.uncurry (Fun.uncurry (reverse_dataflow runner.instrs))
+          |> List.map (make_block runner)
+          |> List.map (Pair.map Fun.id (symeval_range_for_trees elf start))
+          |> List.map (Pair.map Fun.id (extract_branch_targets @@ Arch.pc ()))
+          |> Fun.flip ( @ ) acc
+        with exn ->
+          let brs = List.map fst (reg :> (int * Reg.t list) list) in
+          ( match exn with
+          | MultipleStarts ->
+              warn "Not implemented: MultipleStarts for %t in %s" (pp_ptrs brs) sym.name
+          | _ -> warn "Error processing %s, skipping branches %t" sym.name (pp_ptrs brs)
+          );
+          if List.mem String.equal sym.name names then raise exn
+          else List.map (fun reg -> (reg, Conc [])) brs @ acc
+      ))
+
+let get_branches log names elfname =
+  (* Normally, handled by CommonOpt, but needs to be added for use by Analyse* *)
+  (* Config.File.ensure_loaded Config.Default.config_file; *)
+  if log then base "Finding branch tables used in %s" elfname;
+  let dwarf = Dw.of_file elfname in
+  let elf = dwarf.elf in
+  if log then base "Loaded %s" elfname;
+  Trace.Cache.start @@ Arch.get_isla_config ();
+  let start =
+    Run.Init.init () |> State.copy ~elf |> (Arch.get_abi { args = []; ret = None }).init
+  in
+  debug "Entry state:\n%t" (Pp.topi State.pp start);
+  let answer = process_sym names dwarf start in
+  Isla.Cache.stop ();
+  answer
+
+let symeval_branch_table elfname names =
+  List.iter
+    (fun (br, target) -> base "%#x can jump to %t" br (Pp.top pp_target target))
+    (get_branches true names elfname)
+
+let elf =
+  let doc = "ELF file from which to pull the code" in
+  Arg.(required & pos 0 (some non_dir_file) None & info [] ~docv:"ELF_FILE" ~doc)
+
+let funcs =
+  let doc = "Restrict search to this function. Can be given multiple times." in
+  Arg.(value & opt_all string [] & info ["func"] ~docv:"FUNCTION" ~doc)
+
+let term = Term.(CmdlinerHelper.func_options comopts symeval_branch_table $ elf $ funcs)
+
+let info =
+  let doc =
+    "Symbolically run the required instructions up to and including a branch-register \
+     instruction."
+  in
+  Term.(info "branch-tables" ~doc ~exits)
+
+let command = (term, info)

--- a/src/branchTable/dune
+++ b/src/branchTable/dune
@@ -1,0 +1,6 @@
+(library
+ (name branchTable)
+ (public_name read-dwarf.branchTable)
+ (flags
+  (:standard -open Utils))
+ (libraries utils ast state run))

--- a/src/branchTable/instrsAnalyses.ml
+++ b/src/branchTable/instrsAnalyses.ml
@@ -1,0 +1,259 @@
+(*==================================================================================*)
+(*  BSD 2-Clause License                                                            *)
+(*                                                                                  *)
+(*  Copyright (c) 2020-2021 Thibaut Pérami                                          *)
+(*  Copyright (c) 2020-2021 Dhruv Makwana                                           *)
+(*  Copyright (c) 2019-2021 Peter Sewell                                            *)
+(*  All rights reserved.                                                            *)
+(*                                                                                  *)
+(*  This software was developed by the University of Cambridge Computer             *)
+(*  Laboratory as part of the Rigorous Engineering of Mainstream Systems            *)
+(*  (REMS) project.                                                                 *)
+(*                                                                                  *)
+(*  This project has been partly funded by EPSRC grant EP/K008528/1.                *)
+(*  This project has received funding from the European Research Council            *)
+(*  (ERC) under the European Union's Horizon 2020 research and innovation           *)
+(*  programme (grant agreement No 789108, ERC Advanced Grant ELVER).                *)
+(*  This project has been partly funded by an EPSRC Doctoral Training studentship.  *)
+(*  This project has been partly funded by Google.                                  *)
+(*                                                                                  *)
+(*  Redistribution and use in source and binary forms, with or without              *)
+(*  modification, are permitted provided that the following conditions              *)
+(*  are met:                                                                        *)
+(*  1. Redistributions of source code must retain the above copyright               *)
+(*     notice, this list of conditions and the following disclaimer.                *)
+(*  2. Redistributions in binary form must reproduce the above copyright            *)
+(*     notice, this list of conditions and the following disclaimer in              *)
+(*     the documentation and/or other materials provided with the                   *)
+(*     distribution.                                                                *)
+(*                                                                                  *)
+(*  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''              *)
+(*  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED               *)
+(*  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A                 *)
+(*  PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR             *)
+(*  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,                    *)
+(*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT                *)
+(*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF                *)
+(*  USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND             *)
+(*  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,              *)
+(*  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT              *)
+(*  OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF              *)
+(*  SUCH DAMAGE.                                                                    *)
+(*                                                                                  *)
+(*==================================================================================*)
+
+(** This module is contains some analyses that you can perform on the
+    instructions of a [Runner.t]. *)
+
+open Logs.Logger (struct
+  let str = __MODULE__
+end)
+
+module Runner = Run.Runner
+module Reg = State.Reg
+module Value = Exp.Value
+module ConcreteEval = Exp.ConcreteEval
+module Instr = Trace.Instr
+
+type instructions = (int, Runner.slot) Hashtbl.t
+
+type simple_branches = (int * bool * int) list
+
+type reg_branches = (int * Reg.t list) list
+
+type 'a branch = Simple of int * 'a | Reg of Reg.t list
+
+let try_eval_target addr pc value =
+  let pc_bv = Value.bv @@ BitVec.of_int ~size:64 addr in
+  let module M = struct
+    exception RegExn
+  end in
+  let ctxt = function
+    | Trace.Var.Register reg -> if reg = pc then pc_bv else raise M.RegExn
+    | Trace.Var.(NonDet _ | Read _) -> raise ConcreteEval.Symbolic
+  in
+  try
+    (* PC-relative and absolute addresses are considered simple... *)
+    Simple (ConcreteEval.eval ~ctxt value |> Value.expect_bv |> BitVec.to_int, ())
+    (* ...all others considred indirect *)
+  with M.RegExn ->
+    let regs = ref [] in
+    Ast.Manip.exp_iter_var
+      (function Trace.Var.Register reg -> regs := reg :: !regs | Read _ | NonDet _ -> ())
+      value;
+    Reg !regs
+
+let looks_like_a_branch { Instr.traces = trace_metas; length = _; read = _; written = _; opcode }
+    addr =
+  if Arch.is_ret opcode then None
+  else
+    let pc = Arch.pc () in
+    let falls_thru =
+      List.exists (fun tm -> Option.is_none tm.Instr.jump_target) trace_metas
+      || (Option.is_some @@ Arch.is_bl opcode)
+    in
+    match
+      trace_metas
+      |> List.filter_map (fun tm -> tm.Instr.jump_target)
+      |> List.map (try_eval_target addr pc)
+    with
+    | [] -> None
+    | [Simple (int, ())] -> Some (Simple (int, falls_thru))
+    | [Reg regs] -> Some (Reg regs)
+    | _ :: _ :: _ -> fail "More than one write to PC across traces of instruction."
+
+(** TODO Add tests *)
+let find_branches instructions =
+  let collect_simp_or_reg_branch addr slot ((simp_branches, reg_branches) as branches) =
+    match slot with
+    | Runner.Special _ | Nocode | IslaFail _ -> branches
+    | Normal instr -> (
+        match looks_like_a_branch instr addr with
+        | Some (Simple (target, falls_thru)) ->
+            ((addr, falls_thru, target) :: simp_branches, reg_branches)
+        | Some (Reg regs) -> (simp_branches, (addr, regs) :: reg_branches)
+        | None -> branches
+      )
+  in
+  let (s, r) = Hashtbl.fold collect_simp_or_reg_branch instructions ([], []) in
+  debug "BR: %t" Pp.(top (list ptr) @@ List.map fst r);
+  (s, r)
+
+(** TODO Add tests *)
+let compute_comes_before instructions simp_branches =
+  let comes_before = Hashtbl.create 10 in
+  let cons_value_if_key_in_range key value =
+    if Hashtbl.mem instructions key then
+      match Hashtbl.find_opt comes_before key with
+      | None -> Hashtbl.add comes_before key (value, [])
+      | Some (x, xs) -> Hashtbl.replace comes_before key (value, x :: xs)
+  in
+  let add_next addr length =
+    let next_instr_addr = addr + length in
+    match List.find_opt (fun (addr', _, _) -> addr = addr') simp_branches with
+    (* No simple branches at this address, falls-through to next instruction. *)
+    | None -> cons_value_if_key_in_range next_instr_addr addr
+    (* There is a simple branch at this address, it may fall-through to next instruction. *)
+    | Some (_, falls_thru, target) ->
+        cons_value_if_key_in_range target addr;
+        if falls_thru then cons_value_if_key_in_range next_instr_addr addr
+  in
+  let add_targets_of addr slot =
+    match slot with
+    | Runner.Nocode -> ()
+    | Special length | IslaFail length -> add_next addr length
+    | Normal { traces = _; length; read = _; written = _; opcode } ->
+        if not @@ Arch.is_ret opcode then add_next addr length
+  in
+  Hashtbl.iter add_targets_of instructions;
+  comes_before
+
+(** TODO Add tests *)
+let track_spills instructions simp_branches =
+  let next =
+    let visited = Hashtbl.create 10 in
+    let get addr len =
+      match List.find_opt (fun (addr', _, _) -> addr = addr') simp_branches with
+      | None -> [addr + len]
+      | Some (_, falls_thru, other) -> if falls_thru then [addr + len; other] else [other]
+    in
+    fun addr len ->
+      if Hashtbl.mem visited addr then []
+      else (
+        Hashtbl.add visited addr ();
+        get addr len
+      )
+  in
+  let is_an sps reg = List.mem Reg.( = ) reg sps in
+  let is_reg = function Ast.Var (Trace.Var.Register reg, _) -> Some reg | _ -> None in
+  let is_read = function Ast.Var (Trace.Var.Read (num, _), _) -> Some num | _ -> None in
+  let is_sp sps exp = Option.fold ~none:false ~some:(is_an sps) (is_reg exp) in
+  let is_stack_offset sps = function
+    | Ast.Manyop
+        ( Bvmanyarith Bvadd,
+          [Bits (offset, _); Unop (Extract (_, _), Var (Trace.Var.Register reg, _), _)],
+          _ ) ->
+        if is_an sps reg then Some offset else None
+    | Ast.Unop (Extract (_, _), Var (Trace.Var.Register reg, _), _) ->
+        if is_an sps reg then Some (BitVec.one ~size:1) else None
+    | _ -> None
+  in
+  let sp = Arch.sp () in
+  let result = Hashtbl.create 10 in
+  let rec loop sps spilled addr =
+    let recurse_on length sps spilled = List.iter (loop sps spilled) @@ next addr length in
+    match Hashtbl.find_opt instructions addr with
+    | None | Some Runner.Nocode -> ()
+    | Some (Special len | IslaFail len) -> recurse_on len sps spilled
+    | Some (Normal { Instr.traces; length; read = _; written = _; opcode = _ }) -> (
+        match traces with
+        | [] | _ :: _ :: _ -> recurse_on length sps spilled
+        | [{ Instr.trace; _ }] ->
+            (* I do this to enforce mutual-exclusion of the 6 cases
+               1. instruction does nothing related to spilling
+               2. stack-pointer is copied to another register
+               3. a (non-SP) register which previously held a stack-pointer is clobbered
+                  (by a non-stack-pointer value)
+               4. a register is loading from a stack offset that was previously spilled to
+               5. a register is spilling to a stack offset (and its old value, if any, is clobbered)
+               6. a stack offset that was spilled to is being clobbered *)
+            let (set, get) =
+              let set = ref false in
+              let sps_spilled = ref (sps, spilled) in
+              ( (fun x ->
+                  assert (not !set);
+                  sps_spilled := x),
+                fun () -> !sps_spilled )
+            in
+            let reads = Hashtbl.create 10 in
+            List.iter
+              (function
+                | Trace.ReadMem { addr; value; size = _ } ->
+                    (* track mem reads for later reg writes *) Hashtbl.add reads value addr
+                | WriteReg { reg; value = exp } ->
+                    if is_sp sps exp then
+                      (* 2. stack-pointer is copied to another register *)
+                      set (reg :: sps, spilled)
+                    else if Reg.(reg <> sp) && List.mem Reg.( = ) reg sps then
+                      (* 3. a (non-SP) register which previously held a stack-pointer
+                            is clobbered (by a non-stack-pointer value) *)
+                      set (List.filter (Reg.( <> ) reg) sps, spilled)
+                    else
+                      ignore
+                      @@ Option.(
+                           let* num = is_read exp in
+                           let* read_exp = Hashtbl.find_opt reads num in
+                           let* offset = is_stack_offset sps read_exp in
+                           let* (spill_addr, _, _) =
+                             List.find_opt (fun (_, _, offset') -> offset = offset') spilled
+                           in
+                           (* 4. a register is loading from a stack offset that was
+                                 previously spilled to *)
+                           some @@ Hashtbl.add result addr spill_addr)
+                | WriteMem { addr = loc; value; size = _ } -> (
+                    match (is_stack_offset sps loc, is_reg value) with
+                    | (Some stack_offset, Some reg) ->
+                        (* 5. a register is spilling to a stack offset (and its
+                              old value, if any, is clobbered) *)
+                        set
+                          ( sps,
+                            (addr, reg, stack_offset)
+                            :: List.filter (fun (_, _, x) -> x <> stack_offset) spilled )
+                    | (Some stack_offset, None) ->
+                        (* 6. a stack offset that was spilled to is being clobbered *)
+                        set (sps, List.filter (fun (_, _, x) -> x <> stack_offset) spilled)
+                    | (None, (None | Some _)) -> ()
+                  )
+                | Assert _ -> ())
+              trace;
+            let (sps, spilled) = get () in
+            recurse_on length sps spilled
+      )
+  in
+  let start_instr =
+    Hashtbl.fold (fun key _ min -> if key < min then key else min) instructions Int.max_int
+  in
+  loop [Arch.sp ()] [] start_instr;
+  debug "Spills:";
+  Hashtbl.iter (fun ld spill -> debug "  load %#x from spill %#x" ld spill) result;
+  result

--- a/src/elf/symTable.ml
+++ b/src/elf/symTable.ml
@@ -118,3 +118,7 @@ let of_linksem segments linksem_map =
   List.fold_left add_linksem_sym_to_map empty linksem_map
 
 let pp_raw st = RMap.bindings st.by_addr |> List.map (Pair.map Pp.ptr pp_raw) |> Pp.mapping "syms"
+
+let iter t f = SMap.iter (fun _ value -> f value) t.by_name
+
+let fold t e f = SMap.fold (fun _ value -> f value) t.by_name e

--- a/src/elf/symTable.mli
+++ b/src/elf/symTable.mli
@@ -114,3 +114,9 @@ val of_linksem : Segment.t list -> linksem_t -> t
 
 (** Pretty print the table as a raw ocaml value *)
 val pp_raw : t -> Pp.document
+
+(** Iterate through all the symbols in the table. *)
+val iter : t -> (sym -> unit) -> unit
+
+(** Fold over all the symbols in the table. *)
+val fold : t -> 'a -> (sym -> 'a -> 'a) -> 'a

--- a/src/isla/manip.ml
+++ b/src/isla/manip.ml
@@ -296,6 +296,6 @@ let remove_ignored ignored_regs : 'a trc -> 'a trc = function
         (List.filter
            (function
              | ReadReg (name, _, _, _) | WriteReg (name, _, _, _) ->
-                 not @@ List.mem name ignored_regs
+                 not @@ List.mem String.equal name ignored_regs
              | _ -> true)
            l)

--- a/src/run/funcRD.ml
+++ b/src/run/funcRD.ml
@@ -130,7 +130,7 @@ let run_func_rd elfname name objdump_d branchtables breakpoints =
               let last_pc = st.last_pc in
               let last_instr = Runner.expect_normal runner last_pc in
               Hashtbl.add instr_data (st.last_pc + 4)
-                (Printf.sprintf "End because: %s" s, st, last_instr.footprint))
+                (Printf.sprintf "End because: %s" s, st, Trace.Instr.footprint last_instr))
         tree;
       Vec.iter
         (fun funcaddr ->

--- a/src/simrel/base.ml
+++ b/src/simrel/base.ml
@@ -111,7 +111,7 @@ module RegRel = struct
     map |> Reg.Map.iteri (fun reg tval -> ref := f !ref reg tval);
     !ref
 
-  let present except reg = match except with None -> false | Some x -> List.mem reg x
+  let present except reg = match except with None -> false | Some x -> List.mem Reg.( = ) reg x
 
   (** This is not symmetric (does it need to be?). 
     NOTE: If there is a reg in st2 that is not in st1, it will not be checked.

--- a/src/state/reg.ml
+++ b/src/state/reg.ml
@@ -78,6 +78,8 @@ let index : (Path.t, ty) IdMap.t = IdMap.make ()
 
 let pp_index () = IdMap.pp ~keys:Path.pp ~vals:pp_ty index
 
+let of_int x = if IdMap.mem_id index x then Some x else None
+
 let mem_path = IdMap.mem index
 
 let mem_string = Path.of_string %> mem_path
@@ -121,7 +123,11 @@ let iter f = IdMap.iter f index
 
 let seq_all () = Seq.iota (num ())
 
-let equal = ( = )
+let ( = ) = Int.equal
+
+let ( <> ) x y = not (x = y)
+
+let compare = Int.compare
 
 let pp reg = reg |> to_string |> Pp.string
 

--- a/src/state/reg.mli
+++ b/src/state/reg.mli
@@ -98,6 +98,9 @@ type t = private int
     Use {!IslaConv.ty} to convert *)
 type ty = Ast.no Ast.ty
 
+(** Convert an integer into the corresponding register. *)
+val of_int : int -> t option
+
 (** Check if register is declared with that path *)
 val mem_path : Path.t -> bool
 
@@ -149,7 +152,13 @@ val iter : (Path.t -> t -> ty -> unit) -> unit
 val seq_all : unit -> t Seq.t
 
 (** Equality predicate *)
-val equal : t -> t -> bool
+val ( = ) : t -> t -> bool
+
+(** Inequality predicate *)
+val ( <> ) : t -> t -> bool
+
+(** Compare according to an implementation-defined total order. *)
+val compare : t -> t -> int
 
 (** Pretty prints a register (Just use {!to_string}) *)
 val pp : t -> Pp.document

--- a/src/trace/cache.ml
+++ b/src/trace/cache.ml
@@ -168,4 +168,4 @@ let get_traces (opcode : BytesSeq.t) : Base.t list =
 
 (** Get a full blown {!Instr} from the opcode, going through the whole Isla pipeline
     if necessary.*)
-let get_instr (opcode : BytesSeq.t) : Instr.t = Instr.of_traces @@ get_traces opcode
+let get_instr (opcode : BytesSeq.t) : Instr.t = Instr.of_traces opcode @@ get_traces opcode

--- a/src/trace/instr.ml
+++ b/src/trace/instr.ml
@@ -43,50 +43,68 @@
 (*==================================================================================*)
 
 (** This module provide the representation of an instruction.
-    It only contain generic information about the opcode and not specific
+    It only contains generic information about the opcode and not specific
     information about a place in the code.*)
 
 module Reg = State.Reg
 
-(** A simple trace with it's metadata *)
-type trace_meta = { trace : Base.t; jump : bool; footprint : Reg.t list }
+(** A simple trace with its metadata
+
+    If there is a [WriteReg {reg;value}] event in [trace] where [reg = Arch.pc ()],
+    [jump = Some value], otherwise it is [None]. If there are multiple such events,
+    it will store the value of the last one. *)
+type trace_meta = {
+  trace : Base.t;
+  jump_target : Base.exp option;
+  read : Reg.t list;
+  written : Reg.t list;
+}
 
 (** A full instruction representation *)
-type t = { traces : trace_meta list; length : int;  (** Bytes length *) footprint : Reg.t list }
+type t = {
+  traces : trace_meta list;
+  length : int;  (** Bytes length *)
+  read : Reg.t list;
+  written : Reg.t list;
+  opcode : BytesSeq.t;
+}
 
-(** Helper to access the [footprint] field *)
-let footprint t = t.footprint
+let dedup_regs = List.sort_uniq State.Reg.compare
+
+let footprint x = dedup_regs @@ x.read @ x.written
 
 (** Compute the metadata of trace *)
 let trace_meta_of_trace trace =
   let pc = Arch.pc () in
-  let footprint = ref [] in
-  let jump = ref false in
-  let process_reg reg = footprint := reg :: !footprint in
-  let process_var = function Base.Var.Register reg -> process_reg reg | _ -> () in
+  let read = ref [] in
+  let written = ref [] in
+  let jump = ref None in
+  let process_var = function
+    | Base.Var.Register reg -> read := reg :: !read
+    | Base.Var.(Read _ | NonDet _) -> ()
+  in
   let process_exp : Base.exp -> unit = Ast.Manip.exp_iter_var process_var in
   let process_event : Base.event -> unit = function
     | WriteReg { reg; value } ->
-        process_reg reg;
+        written := reg :: !written;
         process_exp value;
-        if reg = pc then jump := true
-    | ReadMem { addr; _ } -> process_exp addr
-    | WriteMem { addr; value; _ } ->
+        if reg = pc then jump := Some value
+    | ReadMem { addr; value = _; size = _ } -> process_exp addr
+    | WriteMem { addr; value; size = _ } ->
         process_exp addr;
         process_exp value
     | Assert exp -> process_exp exp
   in
   List.iter process_event trace;
-  { trace; jump = !jump; footprint = List.sort_uniq compare !footprint }
+  { trace; jump_target = !jump; read = dedup_regs !read; written = dedup_regs !written }
 
-(** Generate an instruction data from a list of traces *)
-let of_traces traces =
+(** Generate full instruction data from a list of traces *)
+let of_traces opcode traces =
   let traces = List.map trace_meta_of_trace traces in
-  let length = 4 (* TODO *) in
-  let footprint =
-    List.fold_left (fun l (tr : trace_meta) -> List.merge_uniq compare l tr.footprint) [] traces
-  in
-  { traces; length; footprint }
+  let length = BytesSeq.length opcode in
+  let read = dedup_regs @@ List.concat_map (fun (tr : trace_meta) -> tr.read) traces in
+  let written = dedup_regs @@ List.concat_map (fun (tr : trace_meta) -> tr.written) traces in
+  { traces; length; read; written; opcode }
 
 (** Pretty print the representation of an instruction *)
 let pp instr =

--- a/src/utils/bitVec.mli
+++ b/src/utils/bitVec.mli
@@ -296,7 +296,7 @@ val shift_right_logic_bv : t -> t -> t
 (** Concatenates the bitvectors *)
 val concat : t -> t -> t
 
-(** [extract bv a b] extract bits [a] to [b] included from [bv]. Indexs starts at 0 *)
+(** [extract bv a b] extract bits [a] to [b] included from [bv]. Indices start at 0 *)
 val extract : int -> int -> t -> t
 
 (** Add the second argument of zeroes to the left *)

--- a/src/utils/list.ml
+++ b/src/utils/list.ml
@@ -239,6 +239,8 @@ let rec equal eq l1 l2 =
   | (a1 :: t1, a2 :: t2) when eq a1 a2 -> equal eq t1 t2
   | _ -> false
 
+let rec mem eq x = function [] -> false | y :: ys -> eq x y || mem eq x ys
+
 (** If the list have the same length this a lexicographic compare.
     If one list is shorter, then the missing value a considered smaller than any actual values.
 


### PR DESCRIPTION
This is a partial implementation. It can handle simple branch tables (see private tests) but cannot track spills, BL or multiple starts.