### PR TITLE
Morello addr mask

### DIFF
--- a/src/analyse/CallGraph.ml
+++ b/src/analyse/CallGraph.ml
@@ -58,6 +58,10 @@ open ControlFlowTypes
 type call_graph_node = addr * index * string list
 
 let pp_call_graph test (instructions, index_of_address, _address_of_index, _indirect_branches) =
+  let mask_addr x:natural =
+    if !Globals.morello
+    then Nat_big_num.shift_left (Nat_big_num.shift_right x 1) 1
+    else x in
   (* take the nodes to be all the elf symbol addresses of stt_func
      symbol type (each with their list of elf symbol names) together
      with all the other-address bl-targets (of which in Hf there are just
@@ -67,7 +71,7 @@ let pp_call_graph test (instructions, index_of_address, _address_of_index, _indi
       List.sort_uniq compare
         (List.filter_map
            (fun (_name, (typ, _size, address, _mb, _binding)) ->
-             if typ = Elf_symbol_table.stt_func then Some address else None)
+             if typ = Elf_symbol_table.stt_func then Some (mask_addr address) else None)
            test.symbol_map)
     in
     List.map

--- a/src/analyse/Globals.ml
+++ b/src/analyse/Globals.ml
@@ -85,3 +85,5 @@ let src_target_dir = ref (None : string option)
 let copy_sources_dry_run = ref false
 
 let skylight = ref false
+
+let morello = ref false

--- a/src/run/readDwarf.ml
+++ b/src/run/readDwarf.ml
@@ -156,6 +156,11 @@ let html =
       const (fun b -> if b then Analyse.Types.Html else Analyse.Types.Ascii)
       $ Arg.(value & flag & info ["h"; "html"] ~doc))
 
+let morello =
+  let doc = "Enable Morello suppost" in
+  setter Analyse.Globals.morello
+    Arg.(value & flag & info ["morello"] ~docv:"MORELLO" ~doc)
+
 let options =
   [
     skylight;
@@ -178,6 +183,7 @@ let options =
     cfg_source_nodes;
     cfg_source_nodes2;
     html;
+    morello ;
     Logs.term;
   ]
 

--- a/src/run/readDwarf.ml
+++ b/src/run/readDwarf.ml
@@ -157,7 +157,7 @@ let html =
       $ Arg.(value & flag & info ["h"; "html"] ~doc))
 
 let morello =
-  let doc = "Enable Morello suppost" in
+  let doc = "Enable Morello support" in
   setter Analyse.Globals.morello
     Arg.(value & flag & info ["morello"] ~docv:"MORELLO" ~doc)
 


### PR DESCRIPTION
address masking for morello arch. Controlled by --morello command-line option for `rd` command.