### PR TITLE
removing hardcoded paths to HTML files from source

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,5 @@
-(lang dune 2.6)
+(lang dune 2.8)
+(using dune_site 0.1)
 (name "read-dwarf")
 (authors "Peter Sewell" "Thibaut Pérami")
 (maintainers "Peter Sewell <peter.sewell@cl.cam.ac.uk>"
@@ -12,6 +13,7 @@
 (package
  (name read-dwarf)
  (synopsis "C Translation checking software")
+ (sites (share html))
  (depends
   (ocaml (>= 4.08.0))
   (pprint (>= 20171003))

--- a/read-dwarf.opam
+++ b/read-dwarf.opam
@@ -9,7 +9,8 @@ authors: ["Peter Sewell" "Thibaut Pérami"]
 homepage: "https://github.com/rems-project/read-dwarf"
 bug-reports: "https://github.com/rems-project/read-dwarf/issues"
 depends: [
-  "dune" {>= "2.6"}
+  "dune" {>= "2.9.1"}
+  "dune-site"
   "ocaml" {>= "4.08.0"}
   "pprint" {>= "20171003"}
   "menhir" {build}
@@ -25,7 +26,7 @@ depends: [
   "odoc" {with-doc}
 ]
 build: [
-  ["dune" "subst"] {pinned}
+  ["dune" "subst"] {dev}
   [
     "dune"
     "build"
@@ -36,6 +37,15 @@ build: [
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
+  ]
+  [
+    "dune"
+    "install"
+    "-p"
+    name
+    "-j"
+    jobs
+    "--create-install-files"
   ]
 ]
 dev-repo: "git+https://github.com/rems-project/read-dwarf.git"

--- a/src/analyse/Pp.ml
+++ b/src/analyse/Pp.ml
@@ -658,10 +658,20 @@ let chunks_of_ranged_cu m test an filename_stem ((low, high), cu) =
   (title, instructions_chunk :: chunks0)
 
 let wrap_body m (chunk_name, chunk_title, chunk_body) =
+  let read_html name =
+    let rec inter_p = function
+      | [] -> Error "not found"
+      | dir::dirs ->
+         let filename = Filename.concat dir name  in
+         if Sys.file_exists filename
+         then read_file_lines filename
+         else inter_p dirs
+    in inter_p (Htmlpaths.Sites.html)
+  in
   match m with
   | Ascii ->
       ( if chunk_name = "instructions" then
-        match read_file_lines "src/analyse/emacs-highlighting" with
+        match read_html "emacs-highlighting" with
         | Error _ -> "Error: src/analyse/no emacs-highlighting file\n"
         | Ok lines -> String.concat "\n" (Array.to_list lines)
       else ""
@@ -669,17 +679,17 @@ let wrap_body m (chunk_name, chunk_title, chunk_body) =
       ^ "* ************* " ^ chunk_title ^ " **********\n" ^ chunk_body
   | Html -> (
       ( if chunk_name = "instructions" then
-        match read_file_lines "src/analyse/html-preamble-insts.html" with
+        match read_html "html-preamble-insts.html" with
         | Error _ -> "Error: src/analyse/no html-preamble-insts.html file\n"
         | Ok lines -> String.concat "\n" (Array.to_list lines)
       else
-        match read_file_lines "src/analyse/html-preamble.html" with
+        match read_html "html-preamble.html" with
         | Error _ -> "Error: no src/analyse/html-preamble.html file\n"
         | Ok lines -> String.concat "\n" (Array.to_list lines)
       )
       ^ "<h1>" ^ chunk_title ^ "</h1>\n" ^ chunk_body
       ^
-      match read_file_lines "src/analyse/html-postamble.html" with
+      match read_html "html-postamble.html" with
       | Error _ -> "Error: no src/analyse/html-postamble.html file\n"
       | Ok lines -> String.concat "\n" (Array.to_list lines)
     )

--- a/src/analyse/dune
+++ b/src/analyse/dune
@@ -3,4 +3,13 @@
  (public_name read-dwarf.analyse)
  (flags
   (:standard -open Utils))
- (libraries uutf utils))
+ (modules :standard htmlpaths)
+ (libraries dune-site uutf utils))
+
+(install
+ (section (site (read-dwarf html)))
+ (files emacs-highlighting html-preamble.html html-preamble-insts.html html-postamble.html))
+
+(generate_sites_module
+ (module htmlpaths)
+ (sites read-dwarf))

--- a/src/bin/dune
+++ b/src/bin/dune
@@ -20,4 +20,4 @@
  (flags
   (:standard -open Utils))
  (modules copySourcesCmd copySources dumpDwarf dumpSym readDwarf)
- (libraries run utils config analyse state trace))
+ (libraries run utils config state trace))


### PR DESCRIPTION
Paths to the following files:

1. emacs-highlighting
2. html-preamble.html
3. html-postamble.html
4. html-preamble-insts.html

are no longer hard-coded into the source. They are no located at runtime using [dune-sites](https://github.com/ocaml/dune/blob/2.9/doc/sites.rst).

This mechanism works when the package is installed via `opam` as well as when it is executed from local directory using `dune exec`.